### PR TITLE
Instrument device connect failures at both TLS and WebSocket layers (sc-225223)

### DIFF
--- a/lib/nerves_hub/device_ssl_transport.ex
+++ b/lib/nerves_hub/device_ssl_transport.ex
@@ -26,11 +26,40 @@ defmodule NervesHub.DeviceSSLTransport do
     if NervesHub.RateLimit.increment() do
       :telemetry.execute([:nerves_hub, :rate_limit, :accepted], %{count: 1})
 
-      SSL.handshake(socket)
+      # Capture the peer IP BEFORE the handshake. TLS handshake failures — e.g.
+      # `bad_certificate` generated at the `wait_cert_verify` state when a device's
+      # CertificateVerify signature fails (which happens AFTER our `verify_fun` ran
+      # and already bumped the device cert `last_used`) — are otherwise anonymous:
+      # the Erlang SSL alert carries no client identity, so we cannot attribute the
+      # ~thousand/hour TLS failures to a specific device. Grabbing peername up front
+      # (the TCP connection exists post-accept) means we still have the IP even if the
+      # failed handshake tears the socket down. Cross-reference with NLB flow logs
+      # (client IP preserved) to map IP -> device. See sc-225223.
+      peer_ip = peer_ip(socket)
+
+      case SSL.handshake(socket) do
+        {:ok, _} = ok ->
+          ok
+
+        {:error, reason} = error ->
+          :telemetry.execute([:nerves_hub, :devices, :tls_handshake_error], %{count: 1}, %{
+            reason: inspect(reason),
+            peer_ip: peer_ip
+          })
+
+          error
+      end
     else
       :telemetry.execute([:nerves_hub, :rate_limit, :rejected], %{count: 1})
 
       {:error, :closed}
+    end
+  end
+
+  defp peer_ip(socket) do
+    case SSL.peername(socket) do
+      {:ok, {ip, _port}} -> ip |> :inet.ntoa() |> List.to_string()
+      _ -> nil
     end
   end
 

--- a/lib/nerves_hub/logger.ex
+++ b/lib/nerves_hub/logger.ex
@@ -29,6 +29,7 @@ defmodule NervesHub.Logger do
       [
         [:phoenix, :endpoint, :stop],
         [:nerves_hub, :devices, :invalid_auth],
+        [:nerves_hub, :devices, :no_auth],
         [:nerves_hub, :devices, :connect],
         [:nerves_hub, :devices, :connecting_code_failure],
         [:nerves_hub, :devices, :disconnect],
@@ -86,6 +87,16 @@ defmodule NervesHub.Logger do
       |> Map.reject(fn {_key, val} -> is_nil(val) end)
 
     Logger.info("Device auth failed", extra)
+  end
+
+  def log_event([:nerves_hub, :devices, :no_auth], _, metadata, _) do
+    Logger.info("Device connect with no usable auth",
+      event: "nerves_hub.devices.no_auth",
+      reason: to_string(metadata[:reason]),
+      peer_data_present: metadata[:peer_data_present],
+      ssl_cert_present: metadata[:ssl_cert_present],
+      x_headers_present: metadata[:x_headers_present]
+    )
   end
 
   def log_event([:nerves_hub, :devices, :connect], _, metadata, _) do

--- a/lib/nerves_hub/logger.ex
+++ b/lib/nerves_hub/logger.ex
@@ -94,6 +94,7 @@ defmodule NervesHub.Logger do
     Logger.info("Device connect with no usable auth",
       event: "nerves_hub.devices.no_auth",
       reason: to_string(metadata[:reason]),
+      peer_ip: metadata[:peer_ip],
       peer_data_present: metadata[:peer_data_present],
       ssl_cert_present: metadata[:ssl_cert_present],
       x_headers_present: metadata[:x_headers_present]

--- a/lib/nerves_hub/logger.ex
+++ b/lib/nerves_hub/logger.ex
@@ -30,6 +30,7 @@ defmodule NervesHub.Logger do
         [:phoenix, :endpoint, :stop],
         [:nerves_hub, :devices, :invalid_auth],
         [:nerves_hub, :devices, :no_auth],
+        [:nerves_hub, :devices, :tls_handshake_error],
         [:nerves_hub, :devices, :connect],
         [:nerves_hub, :devices, :connecting_code_failure],
         [:nerves_hub, :devices, :disconnect],
@@ -96,6 +97,14 @@ defmodule NervesHub.Logger do
       peer_data_present: metadata[:peer_data_present],
       ssl_cert_present: metadata[:ssl_cert_present],
       x_headers_present: metadata[:x_headers_present]
+    )
+  end
+
+  def log_event([:nerves_hub, :devices, :tls_handshake_error], _, metadata, _) do
+    Logger.info("Device TLS handshake failed",
+      event: "nerves_hub.devices.tls_handshake_error",
+      reason: metadata[:reason],
+      peer_ip: metadata[:peer_ip]
     )
   end
 

--- a/lib/nerves_hub_web/channels/device_socket.ex
+++ b/lib/nerves_hub_web/channels/device_socket.ex
@@ -213,8 +213,15 @@ defmodule NervesHubWeb.DeviceSocket do
           :no_credentials
       end
 
+    peer_ip =
+      case peer_data do
+        %{address: addr} when is_tuple(addr) -> addr |> :inet.ntoa() |> List.to_string()
+        _ -> nil
+      end
+
     :telemetry.execute([:nerves_hub, :devices, :no_auth], %{count: 1}, %{
       reason: reason,
+      peer_ip: peer_ip,
       peer_data_present: not is_nil(peer_data),
       ssl_cert_present: is_map(peer_data) and not is_nil(Map.get(peer_data, :ssl_cert)),
       x_headers_present: is_list(x_headers) and x_headers != []

--- a/lib/nerves_hub_web/channels/device_socket.ex
+++ b/lib/nerves_hub_web/channels/device_socket.ex
@@ -183,7 +183,43 @@ defmodule NervesHubWeb.DeviceSocket do
       {:error, :invalid_auth}
   end
 
-  def connect(_params, _socket, _connect_info) do
+  # No usable client certificate or shared-secret headers were present in the
+  # connect_info at WebSocket-upgrade time.
+  #
+  # This is normally benign noise (health checks, scanners, browsers hitting the
+  # public endpoint). BUT it also silently captures a real failure mode: a device
+  # that DID present a client certificate during the TLS handshake (so the transport
+  # `verify_fun` ran and the device certificate `last_used` was bumped) whose cert
+  # did not survive into `connect_info.peer_data.ssl_cert` at upgrade time (e.g. TLS
+  # session resumption / abbreviated handshake). Those devices land here and, prior
+  # to this instrumentation, produced ZERO server-side logs while showing "cert used,
+  # never connects" in the UI.
+  #
+  # Emit telemetry describing what connect_info actually contained so the two cases
+  # can be told apart in logs. See sc-225223.
+  def connect(_params, _socket, connect_info) do
+    peer_data = Map.get(connect_info, :peer_data)
+    x_headers = Map.get(connect_info, :x_headers)
+
+    reason =
+      cond do
+        # peer_data present but no usable ssl_cert => cert was NOT surfaced to the
+        # socket layer despite (likely) being presented at TLS. This is the bug case.
+        is_map(peer_data) and is_nil(Map.get(peer_data, :ssl_cert)) ->
+          :peer_cert_missing_at_upgrade
+
+        # nothing device-like at all => ordinary no-credentials noise
+        true ->
+          :no_credentials
+      end
+
+    :telemetry.execute([:nerves_hub, :devices, :no_auth], %{count: 1}, %{
+      reason: reason,
+      peer_data_present: not is_nil(peer_data),
+      ssl_cert_present: is_map(peer_data) and not is_nil(Map.get(peer_data, :ssl_cert)),
+      x_headers_present: is_list(x_headers) and x_headers != []
+    })
+
     {:error, :no_auth}
   end
 


### PR DESCRIPTION
## Why

Investigating "device certificate shows *used* but the device never connects" (Shortcut **sc-225223**). Affected field devices show their cert `last_used` updating every few seconds, never appear connected, and produce **zero** server-side log events.

Key insight (corrected during review): **`last_used` bumping does NOT prove the TLS handshake completed.** In mutual TLS the order is: client sends Certificate → our `verify_fun` runs and bumps the device cert `last_used` → *then* client sends CertificateVerify → server validates the signature at the `wait_cert_verify` state. So a device can bump `last_used` and still fail the handshake at CertificateVerify (`bad_certificate` alert). "`last_used` bumps + no logs" is therefore consistent with **two** blind spots at different layers:

- **TLS layer:** device fails CertificateVerify → Erlang SSL `bad_certificate` alert, which carries **no client identity**, so the ~1,000/hour TLS failures can't be attributed to a specific device.
- **WebSocket layer:** device completes TLS fully, but its client cert doesn't surface into `connect_info.peer_data.ssl_cert` at upgrade time → falls into the silent `:no_auth` clause (health-check/scanner noise bucket) → HTTP 401, no logs.

These are **complementary, not competing**. This PR instruments **both** so we can tell which one a given device (e.g. `092190bc-aaf3-47d5-987e-a615c4bc1816`) is actually hitting. Both events now carry the client IP for device attribution. Instrumentation only — **no change to connection behavior**.

## Changes

**1. TLS-layer: peer-IP capture on handshake failure** (`NervesHub.DeviceSSLTransport`)
- Capture `peername` *before* `SSL.handshake/1` (so the IP survives a torn-down failed handshake) and emit `[:nerves_hub, :devices, :tls_handshake_error]` with `peer_ip` + `reason` on error.
- Makes the previously-anonymous TLS failures attributable: cross-reference `peer_ip` with NLB flow logs (client IP preserved) to map IP → device. Answers "is 092190bc among the `wait_cert_verify` failures, or something else?"

**2. WebSocket-layer: instrument the silent `:no_auth` clause** (`NervesHubWeb.DeviceSocket`)
- The fallback `connect/3` clause returned `{:error, :no_auth}` with no telemetry. Now emits `[:nerves_hub, :devices, :no_auth]` classifying `reason` as `:peer_cert_missing_at_upgrade` (peer_data present but `ssl_cert` nil — the bug case) vs `:no_credentials` (ordinary noise), plus `peer_data_present` / `ssl_cert_present` / `x_headers_present`.
- Also carries `peer_ip` (from `peer_data.address`) so `:no_auth` hits are attributable to a specific device via NLB flow logs even when `:peer_cert_missing_at_upgrade` does not fire — symmetric with the TLS-layer event.

**3. Logger handlers** (`NervesHub.Logger`) for both new events (respect the existing `logger_exclusions` mute mechanism); the `:no_auth` handler logs `peer_ip` as well.

## How this resolves the ambiguity
- If 092190bc's IP shows up in `tls_handshake_error` at the same cadence its `last_used` bumps → it's the **TLS/CertificateVerify** path (WS instrumentation would correctly show nothing for it).
- If it does NOT appear there but shows up in `:no_auth` (now with its IP) → it's the **WS-upgrade** path, and `reason` distinguishes the bug (`:peer_cert_missing_at_upgrade`) from noise (`:no_credentials`).

## Validation
- **Compiles clean** on the synced toolchain (**Elixir 1.20.0 / OTP 29.0.1**), including `mix compile --warnings-as-errors`. (Local toolchain was installed to match `.tool-versions` after the upstream sync.)
- Instrumentation logic exercised locally (telemetry attach + direct `connect/3` calls, no DB): `:peer_cert_missing_at_upgrade`, `:no_credentials`, and empty-`x_headers` cases classify correctly; both Logger handlers render without crashing; non-empty `x_headers` correctly dispatches to the shared-secret clause rather than the fallback.
- **Full DB-backed test suite not run locally** (needs Postgres + ClickHouse); there was no pre-existing test coverage for these modules. **CI is the compile/test gate — confirm green before merge.**

## Notes / caveats
- **Fork-only.** Targets `gridpoint-com/nerves_hub_web` `main`; no upstream PR. A confirmed root cause would inform a cleaner upstream fix (e.g. treating "peer_data present but ssl_cert nil" as a distinct condition in the cert-auth clause, and/or session-resumption handling).
- `SSL.peername/1` returns `{:ok, {ip, port}}` per the `ThousandIsland.Transport` behaviour; `peer_data.address` is `:inet.ip_address()` per `Plug`'s typespec (Bandit builds `%{address:, port:, ssl_cert:}`). Both IP extractions guard against nil/malformed values (return `nil`).
- TLS-error logging volume: `tls_handshake_error` fires for every failed handshake (~1,000/hr today). It's behind `logger_exclusions` if it needs muting after the investigation.
- Draft until CI passes and reviewers confirm the telemetry/metadata shape is what we want in Datadog.

Refs: sc-225223